### PR TITLE
Add test type for the case where `separator` is not `string`

### DIFF
--- a/test.js
+++ b/test.js
@@ -7,5 +7,11 @@ test('main', t => {
 	t.deepEqual(splitOnFirst('a---b---c', '---'), ['a', 'b---c']);
 	t.deepEqual(splitOnFirst('a-b-c', '+'), ['a-b-c']);
 	t.deepEqual(splitOnFirst('abc', ''), ['abc']);
-	t.throws(() => splitOnFirst('abc', null), {instanceOf: TypeError, message: 'Expected the arguments to be of type `string`'});
+	
+	t.throws(() => {
+		splitOnFirst('abc', null);
+	}, {
+		instanceOf: TypeError,
+		message: 'Expected the arguments to be of type `string`'
+	});
 });

--- a/test.js
+++ b/test.js
@@ -7,4 +7,5 @@ test('main', t => {
 	t.deepEqual(splitOnFirst('a---b---c', '---'), ['a', 'b---c']);
 	t.deepEqual(splitOnFirst('a-b-c', '+'), ['a-b-c']);
 	t.deepEqual(splitOnFirst('abc', ''), ['abc']);
+	t.throws(() => splitOnFirst('abc', null), {instanceOf: TypeError, message: 'Expected the arguments to be of type `string`'});
 });


### PR DESCRIPTION
This test will make coverage to 100%